### PR TITLE
Update: Replace t.Fail && t.Log() with t.Errorf(). Remove deprecated rand.Seed().

### DIFF
--- a/models/routemodels/route_test.go
+++ b/models/routemodels/route_test.go
@@ -14,23 +14,21 @@ func TestToBytes(t *testing.T) {
 	var r Route
 	encodeData, err := r.ToBytes()
 	if err != nil {
-		t.Fail()
-		return
+		t.Errorf("Error encoding data: %v\n.", err)
 	}
 	t.Log("Encoded Data:", string(encodeData))
+
 	msgPackMarshaledData, err := msgpack.Marshal(&r)
 	if err != nil {
-		t.Fail()
-		t.Log(err)
+		t.Errorf("Error marshalling with msgPack: %v.\n", err)
 	}
-	t.Logf("Encode Data: %v\nMsgPackMarhsaled Data: %v",
+	t.Logf("Encode Data: %v\nMsgPackMarhsaled Data: %v.\n",
 		string(encodeData),
-		string(msgPackMarshaledData))
+		string(msgPackMarshaledData),
+	)
 	if !bytes.Equal(encodeData, msgPackMarshaledData) {
-		t.Fail()
-
+		t.Errorf("Error encoded data not match: got: %v, want: %v.\n", encodeData, msgPackMarshaledData)
 	}
-
 }
 
 func TestGetRouteFromBytes(t *testing.T) {
@@ -38,48 +36,51 @@ func TestGetRouteFromBytes(t *testing.T) {
 	var r Route
 	err := GetRouteFromBytes(n, &r)
 	if err != nil {
-		t.Fail()
-		t.Log(err)
+		t.Errorf("Error getting route from encoded data: %v.\n", err)
 	}
 	t.Log("Decoded Route", r)
 
-	mpBytes, err := msgpack.Marshal(&Route{ID: "something", Type: RouteType("foo"), WebhookURL: "https://google.com"})
+	mpBytes, err := msgpack.Marshal(
+		&Route{
+			ID:         "something",
+			Type:       RouteType("foo"),
+			WebhookURL: "https://google.com",
+		})
 	if err != nil {
-		t.Fail()
-		t.Log(err)
-		return
+		t.Errorf("Error marshalling mpBytes with msgpack: %v.\n", err)
 	}
+
 	var decodedRoute Route
 	err = GetRouteFromBytes(mpBytes, &decodedRoute)
 	if err != nil {
-		t.Fail()
-		t.Log(err)
-		return
+		t.Errorf("Error getting route from encoded data: %v.\n", err)
 	}
-	if !(decodedRoute.ID == "something" && decodedRoute.Type == RouteType("foo") && decodedRoute.WebhookURL == "https://google.com") {
-		t.Fail()
-		t.Log("Wrong Basic Decoding")
+
+	if !(decodedRoute.ID == "something" &&
+		decodedRoute.Type == RouteType("foo") &&
+		decodedRoute.WebhookURL == "https://google.com") {
+		t.Errorf("Error wrong basic decoding.\n")
 	}
-	rand.Seed(time.Now().UnixMilli())
-	intialRoute := Route{ID: strconv.Itoa(rand.Int()),
+
+	rand.NewSource(time.Now().UnixNano())
+	initialRoute := Route{
+		ID:         strconv.Itoa(rand.Int()),
 		WebhookURL: strconv.Itoa(rand.Int()),
 		Type:       RouteType(strconv.Itoa(rand.Int())),
 	}
-	mpBytes, err = msgpack.Marshal(&intialRoute)
+	mpBytes, err = msgpack.Marshal(&initialRoute)
 	if err != nil {
-		t.Fail()
-		t.Log(err)
+		t.Errorf("Error marshalling mpBytes with msgpack: %v.\n", err)
 	}
+
 	err = GetRouteFromBytes(mpBytes, &decodedRoute)
 	if err != nil {
-		t.Fail()
-		t.Log(err)
-		return
-
+		t.Errorf("Error getting route from encoded data: %v.\n", err)
 	}
-	if !(decodedRoute.ID == intialRoute.ID && decodedRoute.Type == intialRoute.Type && decodedRoute.WebhookURL == intialRoute.WebhookURL) {
-		t.Fail()
-		t.Log("Wrong Random Decoding")
+	if !(decodedRoute.ID == initialRoute.ID &&
+		decodedRoute.Type == initialRoute.Type &&
+		decodedRoute.WebhookURL == initialRoute.WebhookURL) {
+		t.Errorf("Error wrong random decoding.\n")
 	}
 }
 
@@ -87,36 +88,32 @@ func TestValid(t *testing.T) {
 	var r Route
 	err := r.Valid()
 	if err != errInvalidRouteID {
-		t.Fail()
-		t.Log("Empty ids shouldn't be allowed")
-		return
+		t.Errorf("Error empty ids shouldn't be allowed.\n")
 	}
+
 	r.ID = "a"
 	err = r.Valid()
 	if err == errInvalidRouteID {
-		t.Fail()
-		t.Log("Non-empty ids should be allowed")
-		return
+		t.Errorf("Error non-empty ids should be allowed.\n")
 	}
+
 	if err != errInvalidRouteType {
-		t.Fail()
-		t.Log("Invalid route type shouldn't allowed")
+		t.Errorf("Error invalid route type shouldn't be allowed.\n")
 	}
+
 	r.Type = REST
 	err = r.Valid()
 	if err == errInvalidRouteType {
-		t.Fail()
-		t.Log("REST type route should be allowed")
+		t.Errorf("Error REST type route should be allowed.\n")
 	}
 
 	if err != errInvalidWebhookURL {
-		t.Fail()
-		t.Log("Invalid url shouldn't be allowed")
+		t.Errorf("Error invalid url shouldn't be allowed.\n")
 	}
+
 	r.WebhookURL = "a"
 	err = r.Valid()
 	if err == errInvalidWebhookURL {
-		t.Fail()
-		t.Log("Valid webhook should be allowed")
+		t.Errorf("Error valid webhook should be allowed.\n")
 	}
 }


### PR DESCRIPTION
Update: Replace t.Fail && t.Log() with t.Errorf(). Remove deprecated rand.Seed().